### PR TITLE
Windows 11 updates (#19)

### DIFF
--- a/windows/bootstrap_windows.ps1
+++ b/windows/bootstrap_windows.ps1
@@ -23,14 +23,17 @@ param (
 
 # Validation
 if ($PSVersionTable.PSEdition -eq "Core") {
-    if ($IsWindows) {
-        Write-Output "Not running on Windows PowerShell"
-        #Write-Output "Running PowerShell Core, invoking Windows PowerShell..."
-        #PowerShell.exe -Command $MyInvocation.Line
-        exit
-    } else {
+    if (!$IsWindows) {
         Write-Output "Not running on Windows"
         exit
+    }
+
+    [System.Version]$windows11AndUp = "10.0.22000"
+    [System.Version]$currentVersion = (Get-ComputerInfo).OsVersion
+    if ($currentVersion -lt $windows11AndUp) {
+        # Windows 10 and below needs Windows PowerShell
+        Write-Output "Not running on Windows PowerShell"
+        exit    
     }
 }    
 if (!(New-Object System.Security.Principal.WindowsPrincipal([System.Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole("Administrators")) {

--- a/windows/bootstrap_windows2.ps1
+++ b/windows/bootstrap_windows2.ps1
@@ -112,7 +112,7 @@ $osType = Get-ComputerInfo | Select-Object WindowsInstallationType -ExpandProper
 Write-Host "OS Type: $osType"
 try {
     $metadataContent = Invoke-WebRequest -Headers @{"Metadata"='true'} -Uri http://169.254.169.254/metadata/instance?api-version=2017-04-02 -UseBasicParsing -TimeOutSec 1 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Content
-} catch [System.Net.WebException],[System.IO.IOException] {
+} catch {
     # No metadata endpoint available, i.e. not running in the cloud
     $metadataContent = $null
 }

--- a/windows/chocolatey-developer.config
+++ b/windows/chocolatey-developer.config
@@ -31,7 +31,7 @@
     <package id="graphviz" />
     <package id="iperf3" />
     <package id="ilspy" />
-    <package id="javaruntime" />
+    <!--package id="javaruntime" /-->
     <package id="jq" />
     <!-- <package id="keepassx" /> -->
     <package id="keepassxc" />

--- a/windows/settings/windowsterminal/profiles.json
+++ b/windows/settings/windowsterminal/profiles.json
@@ -38,7 +38,7 @@
         "list": 
         [
             {
-                "acrylicOpacity": 0.5,
+                "acrylicOpacity": 1,
                 "closeOnExit": "graceful",
                 "colorScheme": "Breeze",
                 "commandline": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
@@ -56,7 +56,7 @@
                 "useAcrylic": false
             },
             {
-                "acrylicOpacity": 0.5,
+                "acrylicOpacity": 1,
                 "background": "#012456",
                 "closeOnExit": "graceful",
                 "colorScheme": "Ocean",
@@ -75,7 +75,7 @@
                 "useAcrylic": false
             },
             {
-                "acrylicOpacity": 0.75,
+                "acrylicOpacity": 1,
                 "closeOnExit": "graceful",
                 "colorScheme": "Campbell",
                 "commandline": "cmd.exe",
@@ -93,7 +93,7 @@
                 "useAcrylic": true
             },
             {
-                "acrylicOpacity": 0.85000002384185791,
+                "acrylicOpacity": 1,
                 "closeOnExit": "never",
                 "colorScheme": "Solarized Dark",
                 "commandline": "Azure",
@@ -112,7 +112,7 @@
                 "useAcrylic": true
             },
             {
-                "acrylicOpacity": 0.5,
+                "acrylicOpacity": 1,
                 "closeOnExit": "graceful",
                 "colorScheme": "Campbell",
                 "commandline": "wsl.exe ~ -d Ubuntu",
@@ -130,7 +130,7 @@
                 "useAcrylic": false
             },
             {
-                "acrylicOpacity": 0.5,
+                "acrylicOpacity": 1,
                 "closeOnExit": "graceful",
                 "colorScheme": "Breeze",
                 "commandline": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",


### PR DESCRIPTION
* Dropping JRE as it needs a business license

* Windows 11

* Fix Windows Terminal transparency